### PR TITLE
Support meltano catalog discovery + selection syntax

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @menzenski

--- a/meltano.yml
+++ b/meltano.yml
@@ -83,14 +83,12 @@ plugins:
         # yamllint disable rule:hyphens
         -   -
               mongodb_connection_string
-            - database_includes
-        -   - mongodb_connection_file
-            - database_includes
+            - database
         -   - documentdb_credential_json_string
-            - database_includes
+            - database
         -   - documentdb_credential_json_string
             - documentdb_credential_json_extra_options
-            - database_includes
+            - database
       # yamllint enable rule:hyphens
       select:
         - '*.*'

--- a/meltano.yml
+++ b/meltano.yml
@@ -93,8 +93,7 @@ plugins:
             - database_includes
       # yamllint enable rule:hyphens
       select:
-        - entity_one.field_one
-        - entity_two.*
+        - '*.*'
       metadata:
         '*':
           replication-key: _id

--- a/meltano.yml
+++ b/meltano.yml
@@ -16,22 +16,18 @@ plugins:
         - about
         - stream-maps
       config:
+        database: test_database
         mongodb_connection_string: mongodb://admin:password@localhost:27017/
-        database_includes:
-          - database: test-database
-            collection: TestDocument
       settings:
+        - name: database
+          kind: string
+          description: Database name from which records will be extracted.
         - name: mongodb_connection_string
           kind: password
           description: |
             MongoDB connection string. See
             https://www.mongodb.com/docs/manual/reference/connection-string/#connection-string-uri-format for specification.
             The password included in this string should be url-encoded. The tap will not url-encode it.
-        - name: mongodb_connection_string_file
-          kind: file
-          description: |
-            Path to a file containing a MongoDB connection string URI. The password included in this string should be
-            url-encoded. The tap will not url-encode it.
         - name: documentdb_credential_json_string
           kind: password
           description: |
@@ -57,10 +53,6 @@ plugins:
             Start date - used for incremental replication only. Log based replication does not support this setting - do
             not provide it unless you are using incremental replication. Defaults to epoch zero time `1970-01-01` if
             tap uses incremental replication method.
-        - name: database_includes
-          kind: array
-          description: |
-            A list of objects, each specifying `database` and `collection` name, to be included in tap output.
         - name: add_record_metadata
           kind: boolean
           description: |
@@ -100,6 +92,9 @@ plugins:
             - documentdb_credential_json_extra_options
             - database_includes
       # yamllint enable rule:hyphens
+      select:
+        - entity_one.field_one
+        - entity_two.*
       metadata:
         '*':
           replication-key: _id

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,4 +71,4 @@ line-length = 120
 target-version = "py311"
 
 [tool.ruff.isort]
-known-third-party = ["pymongo"]
+known-third-party = ["pymongo", "singer_sdk"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ select = [
     "E",
     "F",
     "RUF",
+    "I001",
 ]
 exclude = [
     ".meltano",
@@ -71,4 +72,8 @@ line-length = 120
 target-version = "py311"
 
 [tool.ruff.isort]
-known-third-party = ["pymongo", "singer_sdk"]
+known-third-party = [
+    "pymongo",
+    "singer_sdk",
+    "pendulum",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "menzenski-tap-mongodb"
-version = "0.0.1"
+version = "0.1.0"
 description = "`tap-mongodb` is a Singer tap for mongodb, built with the Meltano Singer SDK."
 readme = "README.md"
 authors = ["Matt Menzenski"]

--- a/tap_mongodb/connector.py
+++ b/tap_mongodb/connector.py
@@ -1,0 +1,108 @@
+from typing import Optional
+from singer_sdk._singerlib.catalog import CatalogEntry, MetadataMapping, Schema
+from logging import Logger, getLogger
+from pymongo import MongoClient
+from typing import Any
+from functools import cached_property
+from pymongo.database import Database
+from pymongo.errors import PyMongoError
+
+from schema import SCHEMA
+
+
+class MongoDBConnector:
+    def __init__(
+        self,
+        connection_string: str,
+        options: dict[str, Any],
+        db_name: str,
+        prefix: Optional[str] = None,
+    ) -> None:
+        self._connection_string = connection_string
+        self._options = options
+        self._db_name = db_name
+        self._prefix: Optional[str] = prefix
+        self._logger: Logger = getLogger(__name__)
+
+    @cached_property
+    def mongo_client(self) -> MongoClient:
+        client: MongoClient = MongoClient(self._connection_string, **self._options)
+        try:
+            client.server_info()
+        except Exception as e:
+            raise RuntimeError("Could not connect to MongoDB") from e
+        return client
+
+    @property
+    def database(self) -> Database:
+        return self.mongo_client[self._db_name]
+
+    def get_fully_qualified_name(
+        self,
+        collection_name: str,
+        prefix: str | None = None,
+        delimiter: str = "_",
+    ) -> str:
+        """Concatenates a fully qualified name from the parts."""
+        parts = []
+
+        if prefix:
+            parts.append(prefix)
+
+        parts.append(self._db_name)
+
+        parts.append(collection_name)
+
+        return delimiter.join(parts)
+
+    def discover_catalog_entry(self, collection_name: str) -> CatalogEntry:
+        """Create `CatalogEntry` object for the given collection."""
+        unique_stream_id = self.get_fully_qualified_name(
+            collection_name, prefix=self._prefix
+        )
+
+        return CatalogEntry(
+            tap_stream_id=unique_stream_id,
+            stream=unique_stream_id,
+            table=collection_name,
+            key_properties=["_id"],
+            schema=Schema.from_dict(SCHEMA),
+            replication_method=None,  # Must be defined by user
+            metadata=MetadataMapping.get_standard_metadata(
+                schema=SCHEMA,
+                replication_method=None,  # Must be defined by user
+                key_properties=["_id"],
+                valid_replication_keys=None,  # Must be defined by user
+            ),
+            database=None,  # Expects single-database context
+            row_count=None,
+            stream_alias=None,
+            replication_key=None,  # Must be defined by user
+        )
+
+    def discover_catalog_entries(self) -> list[dict[str, Any]]:
+        """Return a list of catalog entries from discovery.
+
+        Returns:
+            The discovered catalog entries as a list.
+        """
+        result: list[dict] = []
+        for collection in self.database.list_collection_names():
+            try:
+                self.database[collection].find_one()
+            except PyMongoError:
+                # Skip collections that are not accessible by the authenticated user
+                # This is a common case when using a shared cluster
+                # https://docs.mongodb.com/manual/core/security-users/#database-user-privileges
+                self._logger.info(
+                    f"Skipping collection {self.database.name}.{collection}, user does not have permission to it."
+                )
+                continue
+
+            self._logger.info(
+                f"Discovered collection {self.database.name}.{collection}"
+            )
+            catalog_entry: CatalogEntry = self.discover_catalog_entry(collection)
+            result.append(catalog_entry.to_dict())
+
+        return result

--- a/tap_mongodb/connector.py
+++ b/tap_mongodb/connector.py
@@ -1,13 +1,12 @@
-from typing import Optional
-from singer_sdk._singerlib.catalog import CatalogEntry, MetadataMapping, Schema
-from logging import Logger, getLogger
-from pymongo import MongoClient
-from typing import Any
 from functools import cached_property
+from logging import Logger, getLogger
+from typing import Any, Optional
+
+from pymongo import MongoClient
 from pymongo.database import Database
 from pymongo.errors import PyMongoError
-
 from schema import SCHEMA
+from singer_sdk._singerlib.catalog import CatalogEntry, MetadataMapping, Schema
 
 
 class MongoDBConnector:

--- a/tap_mongodb/connector.py
+++ b/tap_mongodb/connector.py
@@ -5,8 +5,9 @@ from typing import Any, Optional
 from pymongo import MongoClient
 from pymongo.database import Database
 from pymongo.errors import PyMongoError
-from schema import SCHEMA
 from singer_sdk._singerlib.catalog import CatalogEntry, MetadataMapping, Schema
+
+from tap_mongodb.schema import SCHEMA
 
 
 class MongoDBConnector:
@@ -47,8 +48,6 @@ class MongoDBConnector:
 
         if prefix:
             parts.append(prefix)
-
-        parts.append(self._db_name)
 
         parts.append(collection_name)
 

--- a/tap_mongodb/schema.py
+++ b/tap_mongodb/schema.py
@@ -1,0 +1,48 @@
+SCHEMA = {
+    "properties": {
+        "_id": {
+            "description": "The document's _id",
+            "type": [
+                "string",
+                "null",
+            ],
+        },
+        "_sdc_batched_at": {
+            "format": "date-time",
+            "type": [
+                "string",
+                "null",
+            ],
+        },
+        "_sdc_extracted_at": {
+            "format": "date-time",
+            "type": [
+                "string",
+                "null",
+            ],
+        },
+        "clusterTime": {
+            "format": "date-time",
+            "type": [
+                "string",
+                "null",
+            ],
+        },
+        "document": {
+            "additionalProperties": True,
+            "description": "The document from the collection",
+            "type": [
+                "object",
+                "null",
+            ],
+        },
+        "ns": {"additionalProperties": True, "type": ["object", "null"]},
+        "operationType": {
+            "type": [
+                "string",
+                "null",
+            ],
+        },
+    },
+    "type": "object",
+}

--- a/tap_mongodb/schema.py
+++ b/tap_mongodb/schema.py
@@ -36,7 +36,13 @@ SCHEMA = {
                 "null",
             ],
         },
-        "ns": {"additionalProperties": True, "type": ["object", "null"]},
+        "ns": {
+            "additionalProperties": True,
+            "type": [
+                "object",
+                "null",
+            ],
+        },
         "operationType": {
             "type": [
                 "string",

--- a/tap_mongodb/streams.py
+++ b/tap_mongodb/streams.py
@@ -2,33 +2,30 @@
 
 from __future__ import annotations
 
-from typing import Generator
 from datetime import datetime
+from typing import Any, Generator, Iterable
 
-from pendulum import DateTime
-from singer_sdk import PluginBase as TapBaseClass, _singerlib as singer
-from bson.objectid import ObjectId
 from bson.errors import InvalidId
+from bson.objectid import ObjectId
+from connector import MongoDBConnector
+from pendulum import DateTime
+from pymongo import ASCENDING
 from pymongo.collection import Collection
 from pymongo.database import Database
 from pymongo.errors import OperationFailure
-from pymongo import ASCENDING
-from singer_sdk.streams.core import (
-    TypeConformanceLevel,
-    REPLICATION_LOG_BASED,
-    REPLICATION_INCREMENTAL,
-)
-from singer_sdk.helpers._state import increment_state
-from singer_sdk.helpers._util import utc_now
+from singer_sdk import PluginBase as TapBaseClass
+from singer_sdk import _singerlib as singer
 from singer_sdk._singerlib.utils import strptime_to_utc
 from singer_sdk.helpers._catalog import pop_deselected_record_properties
+from singer_sdk.helpers._state import increment_state
 from singer_sdk.helpers._typing import conform_record_data_types
-
-from connector import MongoDBConnector
-
-from typing import Any, Iterable
-
-from singer_sdk.streams.core import Stream
+from singer_sdk.helpers._util import utc_now
+from singer_sdk.streams.core import (
+    REPLICATION_INCREMENTAL,
+    REPLICATION_LOG_BASED,
+    Stream,
+    TypeConformanceLevel,
+)
 
 
 class MongoDBCollectionStream(Stream):

--- a/tap_mongodb/streams.py
+++ b/tap_mongodb/streams.py
@@ -7,7 +7,6 @@ from typing import Any, Generator, Iterable
 
 from bson.errors import InvalidId
 from bson.objectid import ObjectId
-from connector import MongoDBConnector
 from pendulum import DateTime
 from pymongo import ASCENDING
 from pymongo.collection import Collection
@@ -26,6 +25,8 @@ from singer_sdk.streams.core import (
     Stream,
     TypeConformanceLevel,
 )
+
+from tap_mongodb.connector import MongoDBConnector
 
 
 class MongoDBCollectionStream(Stream):

--- a/tap_mongodb/streams.py
+++ b/tap_mongodb/streams.py
@@ -2,16 +2,13 @@
 
 from __future__ import annotations
 
-from os import PathLike
-from typing import Iterable, Any, Generator
+from typing import Generator
 from datetime import datetime
 
 from pendulum import DateTime
 from singer_sdk import PluginBase as TapBaseClass, _singerlib as singer
-from singer_sdk.streams import Stream
 from bson.objectid import ObjectId
 from bson.errors import InvalidId
-from pymongo.mongo_client import MongoClient
 from pymongo.collection import Collection
 from pymongo.database import Database
 from pymongo.errors import OperationFailure
@@ -27,8 +24,14 @@ from singer_sdk._singerlib.utils import strptime_to_utc
 from singer_sdk.helpers._catalog import pop_deselected_record_properties
 from singer_sdk.helpers._typing import conform_record_data_types
 
+from connector import MongoDBConnector
 
-class CollectionStream(Stream):
+from typing import Any, Iterable
+
+from singer_sdk.streams.core import Stream
+
+
+class MongoDBCollectionStream(Stream):
     """Stream class for mongodb streams."""
 
     # The output stream will always have _id as the primary key
@@ -46,14 +49,26 @@ class CollectionStream(Stream):
     def __init__(
         self,
         tap: TapBaseClass,
-        schema: str | PathLike | dict[str, Any] | singer.Schema | None = None,
-        name: str | None = None,
-        collection: Collection | None = None,
-        mongo_client: MongoClient | None = None,
+        catalog_entry: dict,
+        connector: MongoDBConnector,
     ) -> None:
-        super().__init__(tap, schema, name)
-        self._collection: Collection = collection
-        self._mongo_client: MongoClient = mongo_client
+        """Initialize the database stream.
+
+        If `connector` is omitted, a new connector will be created.
+
+        Args:
+            tap: The parent tap object.
+            catalog_entry: Catalog entry dict.
+            connector: Connector to reuse.
+        """
+        self._connector: MongoDBConnector = connector
+        self.catalog_entry = catalog_entry
+        self._collection_name: str = self.catalog_entry["table_name"]
+        super().__init__(
+            tap=tap,
+            schema=self.catalog_entry["schema"],
+            name=self.catalog_entry["tap_stream_id"],
+        )
 
     def _increment_stream_state(
         self, latest_record: dict[str, Any], *, context: dict | None = None
@@ -146,6 +161,8 @@ class CollectionStream(Stream):
 
         should_add_metadata: bool = self.config.get("add_record_metadata", False)
 
+        collection: Collection = self._connector.database[self._collection_name]
+
         if self.replication_method == REPLICATION_INCREMENTAL:
             start_date: ObjectId | None = None
             if bookmark:
@@ -161,7 +178,7 @@ class CollectionStream(Stream):
                 start_date_dt: datetime = strptime_to_utc(start_date_str)
                 start_date = ObjectId.from_datetime(start_date_dt)
 
-            for record in self._collection.find({"_id": {"$gt": start_date}}).sort(
+            for record in collection.find({"_id": {"$gt": start_date}}).sort(
                 [("_id", ASCENDING)]
             ):
                 object_id: ObjectId = record["_id"]
@@ -182,25 +199,25 @@ class CollectionStream(Stream):
             keep_open: bool = True
 
             try:
-                change_stream = self._collection.watch(**change_stream_options)
+                change_stream = collection.watch(**change_stream_options)
             except OperationFailure as e:
                 if (
                     e.code == 136
                     and "modifyChangeStreams has not been run" in e.details["errmsg"]
                     and self.config["allow_modify_change_streams"]
                 ):
-                    admin_db: Database = self._mongo_client["admin"]
+                    admin_db: Database = self._connector.mongo_client["admin"]
                     result = admin_db.command(
                         "modifyChangeStreams",
-                        database=self._collection.database.name,
-                        collection=self._collection.name,
+                        database=collection.database.name,
+                        collection=collection.name,
                         enable=True,
                     )
                     if result and result["ok"]:
-                        change_stream = self._collection.watch(**change_stream_options)
+                        change_stream = collection.watch(**change_stream_options)
                     else:
                         raise RuntimeError(
-                            f"Unable to enable change streams on collection {self._collection}"
+                            f"Unable to enable change streams on collection {collection.name}"
                         )
                 else:
                     raise e

--- a/tap_mongodb/tap.py
+++ b/tap_mongodb/tap.py
@@ -1,16 +1,17 @@
 """mongodb tap class."""
 
 from __future__ import annotations
-from typing import Any
-from functools import cached_property
 
+import json
+from functools import cached_property
+from typing import Any
+from urllib.parse import quote_plus
+
+from connector import MongoDBConnector
 from singer_sdk import Tap
 from singer_sdk import typing as th  # JSON schema typing helpers
 
 from tap_mongodb.streams import MongoDBCollectionStream
-import json
-from urllib.parse import quote_plus
-from connector import MongoDBConnector
 
 
 class TapMongoDB(Tap):

--- a/tap_mongodb/tap.py
+++ b/tap_mongodb/tap.py
@@ -2,21 +2,15 @@
 
 from __future__ import annotations
 from typing import Any
-from pymongo.mongo_client import MongoClient
-from pymongo.collection import Collection
-from pymongo.errors import PyMongoError
-import sys
-
-from pathlib import Path
+from functools import cached_property
 
 from singer_sdk import Tap
 from singer_sdk import typing as th  # JSON schema typing helpers
 
-from singer_sdk._singerlib.catalog import Catalog, CatalogEntry
-
-from tap_mongodb.streams import CollectionStream
+from tap_mongodb.streams import MongoDBCollectionStream
 import json
 from urllib.parse import quote_plus
+from connector import MongoDBConnector
 
 
 class TapMongoDB(Tap):
@@ -25,6 +19,12 @@ class TapMongoDB(Tap):
     name = "tap-mongodb"
 
     config_jsonschema = th.PropertiesList(
+        th.Property(
+            "database",
+            th.StringType,
+            required=True,
+            description="Database name from which records will be extracted.",
+        ),
         th.Property(
             "mongodb_connection_string",
             th.StringType,
@@ -35,12 +35,6 @@ class TapMongoDB(Tap):
                 "https://www.mongodb.com/docs/manual/reference/connection-string/#connection-string-uri-format "
                 "for specification."
             ),
-        ),
-        th.Property(
-            "mongodb_connection_string_file",
-            th.StringType,
-            required=False,
-            description="Path (relative or absolute) to a file containing a MongoDB connection string URI.",
         ),
         th.Property(
             "documentdb_credential_json_string",
@@ -81,19 +75,6 @@ class TapMongoDB(Tap):
                 "Start date. This is used for incremental replication only. Log based replication does not support "
                 "this setting - do not provide it unless using the incremental replication method. Defaults to "
                 "epoch zero time 1970-01-01 if tap uses incremental replication method."
-            ),
-        ),
-        th.Property(
-            "database_includes",
-            th.ArrayType(
-                th.ObjectType(
-                    th.Property("database", th.StringType, required=True),
-                    th.Property("collection", th.StringType, required=True),
-                ),
-            ),
-            required=True,
-            description=(
-                "A list of objects, each specifying database and collection name, to be included in tap output."
             ),
         ),
         th.Property(
@@ -171,28 +152,6 @@ class TapMongoDB(Tap):
             )
             return connection_string
 
-        mongodb_connection_string_file = self.config.get(
-            "mongodb_connection_string_file", None
-        )
-        if mongodb_connection_string_file is not None:
-            self.logger.debug(
-                f"Using mongodb_connection_string_file: {mongodb_connection_string_file}"
-            )
-            if Path(mongodb_connection_string_file).exists():
-                self.logger.debug("mongodb_connection_string_file exists")
-                try:
-                    connection_string = (
-                        Path(mongodb_connection_string_file).read_text().strip()
-                    )
-                    return connection_string
-                except Exception as e:
-                    self.logger.critical(
-                        f"The MongoDB connection string file '{mongodb_connection_string_file}' has errors: {e}"
-                    )
-                    sys.exit(1)
-            else:
-                self.logger.info("mongodb_connection_string_file is not file")
-
         self.logger.debug("Using mongodb_connection_string")
         return self.config.get("mongodb_connection_string", None)
 
@@ -204,131 +163,44 @@ class TapMongoDB(Tap):
             return {}
         return json.loads(documentdb_credential_json_extra_options_string)
 
-    def get_mongo_client(self) -> MongoClient:
-        client: MongoClient = MongoClient(
-            self._get_mongo_connection_string(), **self._get_mongo_options()
+    @cached_property
+    def connector(self) -> MongoDBConnector:
+        return MongoDBConnector(
+            self._get_mongo_connection_string(),
+            self._get_mongo_options(),
+            self.config.get("database"),
+            prefix=self.config.get("prefix", None),
         )
-        try:
-            client.server_info()
-        except Exception as e:
-            raise RuntimeError("Could not connect to MongoDB") from e
-        return client
 
     @property
     def catalog_dict(self) -> dict:
-        # Use cached catalog if available
+        """Get catalog dictionary.
+
+        Returns:
+            The tap's catalog as a dict
+        """
         if hasattr(self, "_catalog_dict") and self._catalog_dict:
             return self._catalog_dict
-        # Defer to passed in catalog if available
+
         if self.input_catalog:
             return self.input_catalog.to_dict()
-        catalog = Catalog()
-        client: MongoClient = self.get_mongo_client()
-        for included in self.config.get("database_includes", []):
-            db_name = included["database"]
-            collection = included["collection"]
-            try:
-                client[db_name][collection].find_one()
-            except PyMongoError:
-                # Skip collections that are not accessible by the authenticated user
-                # This is a common case when using a shared cluster
-                # https://docs.mongodb.com/manual/core/security-users/#database-user-privileges
-                self.logger.info(
-                    f"Skipping collections {db_name}.{collection}, authenticated user does not have permission to it."
-                )
-                continue
 
-            self.logger.info("Discovered collection %s.%s", db_name, collection)
-            prefix = f"{self.config['prefix']}_" if self.config["prefix"] else ""
-            stream_name = f"{prefix}{db_name}_{collection}".replace("-", "_").lower()
-            entry = CatalogEntry.from_dict({"tap_stream_id": stream_name})
-            entry.stream = stream_name
-            schema = {
-                "type": "object",
-                "properties": {
-                    "_id": {
-                        "type": [
-                            "string",
-                            "null",
-                        ],
-                        "description": "The document's _id",
-                    },
-                    "document": {
-                        "type": [
-                            "object",
-                            "null",
-                        ],
-                        "additionalProperties": True,
-                        "description": "The document from the collection",
-                    },
-                    "operationType": {
-                        "type": [
-                            "string",
-                            "null",
-                        ]
-                    },
-                    "clusterTime": {
-                        "type": [
-                            "string",
-                            "null",
-                        ],
-                        "format": "date-time",
-                    },
-                    "ns": {
-                        "type": [
-                            "object",
-                            "null",
-                        ],
-                        "additionalProperties": True,
-                    },
-                    "_sdc_extracted_at": {
-                        "type": [
-                            "string",
-                            "null",
-                        ],
-                        "format": "date-time",
-                    },
-                    "_sdc_batched_at": {
-                        "type": [
-                            "string",
-                            "null",
-                        ],
-                        "format": "date-time",
-                    },
-                },
-            }
-            entry.schema = entry.schema.from_dict(schema)
-            entry.key_properties = ["_id"]
-            entry.metadata = entry.metadata.get_standard_metadata(
-                schema=schema,
-                key_properties=["_id"],
-                valid_replication_keys=["_id"],
-            )
-            entry.database = db_name
-            entry.table = collection
-            catalog.add_stream(entry)
+        result: dict[str, list[dict]] = {"streams": []}
+        result["streams"].extend(self.connector.discover_catalog_entries())
 
-        self._catalog_dict = catalog.to_dict()
+        self._catalog_dict: dict = result
         return self._catalog_dict
 
-    def discover_streams(self) -> list[CollectionStream]:
+    def discover_streams(self) -> list[MongoDBCollectionStream]:
         """Return a list of discovered streams.
 
         Returns:
             A list of discovered streams.
         """
-        client: MongoClient = self.get_mongo_client()
-        for entry in self.catalog.streams:
-            collection: Collection = client[entry.database][entry.table]
-            stream = CollectionStream(
-                tap=self,
-                name=entry.tap_stream_id,
-                schema=entry.schema,
-                collection=collection,
-                mongo_client=client,
-            )
-            stream.apply_catalog(self.catalog)
-            yield stream
+        return [
+            MongoDBCollectionStream(self, catalog_entry, connector=self.connector)
+            for catalog_entry in self.catalog_dict["streams"]
+        ]
 
 
 if __name__ == "__main__":

--- a/tap_mongodb/tap.py
+++ b/tap_mongodb/tap.py
@@ -7,10 +7,10 @@ from functools import cached_property
 from typing import Any
 from urllib.parse import quote_plus
 
-from connector import MongoDBConnector
 from singer_sdk import Tap
 from singer_sdk import typing as th  # JSON schema typing helpers
 
+from tap_mongodb.connector import MongoDBConnector
 from tap_mongodb.streams import MongoDBCollectionStream
 
 

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -3,7 +3,7 @@
 from singer_sdk.testing import get_tap_test_class
 
 from tap_mongodb.tap import TapMongoDB
-from tap_mongodb.streams import CollectionStream
+from tap_mongodb.streams import MongoDBCollectionStream
 from pymongo.mongo_client import MongoClient
 from pymongo.database import Database
 
@@ -31,7 +31,7 @@ def test_one_stream_is_discovered():
 
         # when the tap's discover_streams method is invoked
         tap: TapMongoDB = TapMongoDB(config=SAMPLE_CONFIG)
-        streams: list[CollectionStream] = tap.discover_streams()
+        streams: list[MongoDBCollectionStream] = tap.discover_streams()
 
         # then a stream for that collection is returned
         for stream in streams:

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -1,11 +1,11 @@
 """Tests standard tap features using the built-in SDK tests library."""
 
+from pymongo.database import Database
+from pymongo.mongo_client import MongoClient
 from singer_sdk.testing import get_tap_test_class
 
-from tap_mongodb.tap import TapMongoDB
 from tap_mongodb.streams import MongoDBCollectionStream
-from pymongo.mongo_client import MongoClient
-from pymongo.database import Database
+from tap_mongodb.tap import TapMongoDB
 
 included_database = {
     "database": "test_service",


### PR DESCRIPTION
**Changes**

* The tap is now limited to a single MongoDB/DocumentDB database, which must be specified in a required `database` config setting.
* The tap now supports dynamic catalog discovery via e.g., `meltano select tap-mongodb --list --all`
* Remove support for `mongodb_connection_string_file` config option